### PR TITLE
add: LICENSE

### DIFF
--- a/graphics/libGLU/Makefile
+++ b/graphics/libGLU/Makefile
@@ -11,11 +11,20 @@ DISTNAME=	glu-${PORTVERSION}
 MAINTAINER=	x11@FreeBSD.org
 COMMENT=	OpenGL utility library
 
+LICENSE=       SGIB2
+LICENSE_NAME=  SGI Free Software License B v2.0
+LICENSE_FILE=  ${WRKSRC}/LICENSE
+LICENSE_PERMS= auto-accept dist-mirror dist-sell pkg-mirror
+
 USES=		gl libtool pathfix pkgconfig tar:xz xorg
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS=	--disable-static
 INSTALL_TARGET=	install-strip
 USE_GL=		gl
 USE_LDCONFIG=	yes
+
+post-extract:
+	@${HEAD} -29 ${WRKSRC}/include/GL/glu.h | \
+		${CUT} -c 4- > ${WRKSRC}/LICENSE
 
 .include <bsd.port.mk>


### PR DESCRIPTION
The license text was extracted from the header of include/GL/glu.h and filed into a file.